### PR TITLE
Add AppIndicator extension to fix system tray icons

### DIFF
--- a/roles/gnome/files/appindicator.conf
+++ b/roles/gnome/files/appindicator.conf
@@ -1,0 +1,3 @@
+[/]
+icon-size=18
+icon-opacity=240

--- a/roles/gnome/tasks/main.yml
+++ b/roles/gnome/tasks/main.yml
@@ -152,6 +152,7 @@
       - gnome-shell-extension-no-overview
       - gnome-shell-extension-system-monitor-applet
       - gnome-shell-extension-user-theme
+      - gnome-shell-extension-appindicator
 
 - name: Remove user-installed extensions now managed by DNF
   file:
@@ -161,6 +162,7 @@
     - caffeine@patapon.info
     - no-overview@fthx
     - system-monitor-next@paradoxxx.zero.gmail.com
+    - appindicator@rgcjonas.gmail.com
 
 - name: Create user extensions directory
   file:
@@ -211,7 +213,7 @@
 - name: Enable GNOME Shell extensions
   community.general.dconf:
     key: /org/gnome/shell/enabled-extensions
-    value: "['caffeine@patapon.info', 'ddterm@amezin.github.com', 'no-overview@fthx', 'unite@hardpixel.eu', 'nordvpnquicktoggle@wedaxi.com', 'system-monitor-next@paradoxxx.zero.gmail.com', 'user-theme@gnome-shell-extensions.gcampax.github.com']"
+    value: "['appindicator@rgcjonas.gmail.com', 'caffeine@patapon.info', 'ddterm@amezin.github.com', 'no-overview@fthx', 'unite@hardpixel.eu', 'nordvpnquicktoggle@wedaxi.com', 'system-monitor-next@paradoxxx.zero.gmail.com', 'user-theme@gnome-shell-extensions.gcampax.github.com']"
 
 - name: Configure caffeine
   shell: "dconf load /org/gnome/shell/extensions/caffeine/ < {{ role_path }}/files/caffeine.conf"
@@ -221,6 +223,9 @@
 
 - name: Configure unite
   shell: "dconf load /org/gnome/shell/extensions/unite/ < {{ role_path }}/files/unite.conf"
+
+- name: Configure appindicator
+  shell: "dconf load /org/gnome/shell/extensions/appindicator/ < {{ role_path }}/files/appindicator.conf"
 
 - name: Remind user to log out and back in
   debug:


### PR DESCRIPTION
## Summary

- Install gnome-shell-extension-appindicator via DNF alongside the other shell extensions
- Remove stale user-installed appindicator@rgcjonas.gmail.com if present (prevents conflicts)
- Enable appindicator@rgcjonas.gmail.com in the enabled-extensions dconf list
- Add roles/gnome/files/appindicator.conf with icon-size=18, icon-opacity=240 and load via dconf

## Why

Slack, Discord, and Zoom use the AppIndicator/KStatusNotifierItem protocol for tray icons. Without a proper AppIndicator extension, GNOME renders them pixelated, stretched, or with wrong background colors against the Dracula purple panel.

## Test plan

- [ ] Run chezmoi apply then the ansible gnome role
- [ ] Log out and back in
- [ ] Run gnome-extensions list --enabled and confirm appindicator@rgcjonas.gmail.com appears
- [ ] Slack tray icon: sharp, correct size, transparent background
- [ ] Discord tray icon: sharp, correct size
- [ ] Zoom tray icon: correct size (no longer stretched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)